### PR TITLE
Fixed character encoding issue on News page

### DIFF
--- a/news.html
+++ b/news.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+        <meta charset="UTF-8">
         <title>News | Press Coverage</title>
         <link rel="stylesheet" href="/css/bootstrap.min.css" />
         <link rel="stylesheet" href="/css/news.css" />


### PR DESCRIPTION
As per Dr. Ishaq's request, this fixes the character encoding issue that caused symbols like "â€œ" to show up on the News page whenever specific symbols like quotations were used. This issue can be seen on this page: https://icaf.org/news.html. 
![News Page](https://github.com/vinays84/ICAF/assets/90157622/86b5064d-6ae7-48c0-ad9c-f090b347095f)

The News page is currently using 'windows-1252' character encoding, whereas all other pages are using 'UTF-8'. This change updates the character encoding of the News page to 'UTF-8'.